### PR TITLE
Checkbox default value

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,6 +38,7 @@
                                   [cljsjs/react-dom "16.8.1-0"]
                                   [cljsjs/react-dom-server "16.8.1-0"]
                                   [com.andrewmcveigh/cljs-time "0.5.2"]
+                                  [com.taoensso/timbre "5.1.2"]
                                   [compojure "1.6.1"]
                                   [cprop "0.1.13"]
                                   [figwheel-sidecar "0.5.18"]

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -122,7 +122,6 @@
   [{:keys [READ UPDATE  valpath default-value]}]
   (let [v (READ valpath)
         dv (boolean default-value)]
-    (log/info (str "IS V BOOLEAN?: " v))
     (if (boolean? v)
       v
       (UPDATE valpath (constantly dv)))))

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -122,6 +122,7 @@
   [{:keys [READ UPDATE  valpath default-value]}]
   (let [v (READ valpath)
         dv (boolean default-value)]
+    (log/info (str "IS V BOOLEAN?: " v))
     (if (boolean? v)
       v
       (UPDATE valpath (constantly dv)))))
@@ -130,13 +131,13 @@
   "Create a checkbox"
   [{:keys [READ UPDATE valpath] :as fn-map}
    {:keys [validation-function disabled style-classes default-value] :as input-map}]
-  (log/info (str "valpath: " valpath))
-  (let [checked? (checkset (merge fn-map {:default-value default-value})) ;;(READ valpath)
+  (log/info (str "RIGHT NOW VALUE IS:" (READ valpath)))
+  (let [checked? (if default-value {:default-value default-value} false)
         toggle-fn (comp (or validation-function identity)
                         #(UPDATE valpath not))]
     [:input {:class (into [(last valpath)] style-classes)
              :type "checkbox"
-             :checked checked? ;;TODO this overwrites on-change, so it's always default-value
+             :defaultChecked checked?
              :disabled disabled
              :on-change toggle-fn}]))
 

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -130,13 +130,13 @@
   "Create a checkbox"
   [{:keys [READ UPDATE valpath] :as fn-map}
    {:keys [validation-function disabled style-classes default-value] :as input-map}]
-  (log/info (:value input-map))
+  (log/info (str "valpath: " valpath))
   (let [checked? (checkset (merge fn-map {:default-value default-value})) ;;(READ valpath)
         toggle-fn (comp (or validation-function identity)
                         #(UPDATE valpath not))]
     [:input {:class (into [(last valpath)] style-classes)
              :type "checkbox"
-             :checked checked?
+             :checked checked? ;;TODO this overwrites on-change, so it's always default-value
              :disabled disabled
              :on-change toggle-fn}]))
 
@@ -145,7 +145,6 @@
   [{:keys [label content valpath READ UPDATE default-value override-inline? open-height disabled style-classes]
     :or {open-height "5em"}
     :as opt-map}]
-  (log/info (str "TOGGLE!! " opt-map))
   (let [content-id "togglebox-content"
         checked? (checkset opt-map)
         transition-style {:-webkit-transition "height 0.4s ease-in-out"

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -122,6 +122,7 @@
   [{:keys [READ UPDATE  valpath default-value]}]
   (let [v (READ valpath)
         dv (boolean default-value)]
+    (log/info (str "v & dv = " v " & " dv))
     (if (boolean? v)
       v
       (UPDATE valpath (constantly dv)))))
@@ -130,13 +131,13 @@
   "Create a checkbox"
   [{:keys [READ UPDATE valpath] :as fn-map}
    {:keys [validation-function disabled style-classes default-value] :as input-map}]
-  (log/info (str "RIGHT NOW VALUE IS:" (READ valpath)))
-  (let [checked? (if default-value {:default-value default-value} false)
+  (let [checked? (checkset (merge fn-map {:default-value default-value}))
         toggle-fn (comp (or validation-function identity)
                         #(UPDATE valpath not))]
     [:input {:class (into [(last valpath)] style-classes)
              :type "checkbox"
-             :defaultChecked checked?
+             ;;:defaultChecked default-value
+             :checked checked?
              :disabled disabled
              :on-change toggle-fn}]))
 
@@ -145,13 +146,14 @@
   [{:keys [label content valpath READ UPDATE default-value override-inline? open-height disabled style-classes]
     :or {open-height "5em"}
     :as opt-map}]
+  (log/info opt-map)
   (let [content-id "togglebox-content"
         checked? (checkset opt-map)
         transition-style {:-webkit-transition "height 0.4s ease-in-out"
                           :transition "height 0.4s ease-in-out"
                           :overflow "hidden"}]
     [:div.togglebox
-     [tinput (select-keys opt-map [:READ :UPDATE :style-classes]) valpath
+     [tinput (select-keys opt-map [:READ :UPDATE :default-value :style-classes]) valpath
       {:type :checkbox
        :checked checked?
        :disabled disabled

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -122,21 +122,21 @@
   [{:keys [READ UPDATE  valpath default-value]}]
   (let [v (READ valpath)
         dv (boolean default-value)]
-    (log/info (str "v & dv = " v " & " dv))
     (if (boolean? v)
       v
-      (UPDATE valpath (constantly dv)))))
+      (do
+        #(UPDATE valpath (constantly dv))
+        dv))))
 
 (defn checkbox
   "Create a checkbox"
-  [{:keys [READ UPDATE valpath] :as fn-map}
-   {:keys [validation-function disabled style-classes default-value] :as input-map}]
+  [{:keys [_READ UPDATE valpath] :as fn-map}
+   {:keys [validation-function disabled style-classes default-value] :as _input-map}]
   (let [checked? (checkset (merge fn-map {:default-value default-value}))
         toggle-fn (comp (or validation-function identity)
                         #(UPDATE valpath not))]
     [:input {:class (into [(last valpath)] style-classes)
              :type "checkbox"
-             ;;:defaultChecked default-value
              :checked checked?
              :disabled disabled
              :on-change toggle-fn}]))
@@ -146,7 +146,6 @@
   [{:keys [label content valpath READ UPDATE default-value override-inline? open-height disabled style-classes]
     :or {open-height "5em"}
     :as opt-map}]
-  (log/info opt-map)
   (let [content-id "togglebox-content"
         checked? (checkset opt-map)
         transition-style {:-webkit-transition "height 0.4s ease-in-out"
@@ -181,7 +180,7 @@
               type "text"}} opt-map
         {:keys [limit enforce?]} char-count
         {:keys [field-key contingent-fn]} contingent
-        _init (when (and default-value (not (READ valpath)))
+        _init (when (and default-value (nil? (READ valpath)))
                 (UPDATE valpath (constantly default-value)))
         input-value (or (READ valpath) default-value)
         changefn1 (fn [e] (UPDATE valpath #(shared/get-value-from-change e)))

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -5,8 +5,7 @@
             ;[reformation.validation :as vali]
             #?(:cljs [reagent.core :refer [atom]])
             [clojure.string :as str]
-
-            ))
+            [taoensso.timbre :as log]))
 (declare tinput render-application render-review)
 
 (defn map-structure
@@ -118,19 +117,6 @@
                        (.setCustomValidity dom-element "")
                        (.setCustomValidity dom-element error-message)))) {:validation-function? true})))
 
-
-(defn checkbox
-  "Create a checkbox"
-  [{:keys [READ UPDATE valpath] :as fn-map}
-   {:keys [validation-function disabled style-classes] :as input-map}]
-  (let [checked? (READ valpath)
-        toggle-fn (comp (or validation-function identity)
-                        #(UPDATE valpath not))]
-    [:input {:class (into [(last valpath)] style-classes)
-             :type "checkbox"
-             :disabled disabled
-             :on-change toggle-fn}]))
-
 (defn checkset
   "If a checkbox value is nil, set it; otherwise, return it."
   [{:keys [READ UPDATE  valpath default-value]}]
@@ -140,12 +126,26 @@
       v
       (UPDATE valpath (constantly dv)))))
 
+(defn checkbox
+  "Create a checkbox"
+  [{:keys [READ UPDATE valpath] :as fn-map}
+   {:keys [validation-function disabled style-classes default-value] :as input-map}]
+  (log/info (:value input-map))
+  (let [checked? (checkset (merge fn-map {:default-value default-value})) ;;(READ valpath)
+        toggle-fn (comp (or validation-function identity)
+                        #(UPDATE valpath not))]
+    [:input {:class (into [(last valpath)] style-classes)
+             :type "checkbox"
+             :checked checked?
+             :disabled disabled
+             :on-change toggle-fn}]))
 
 (defn togglebox
   "Builds a group which, when toggled, displays its `:content`"
   [{:keys [label content valpath READ UPDATE default-value override-inline? open-height disabled style-classes]
     :or {open-height "5em"}
     :as opt-map}]
+  (log/info (str "TOGGLE!! " opt-map))
   (let [content-id "togglebox-content"
         checked? (checkset opt-map)
         transition-style {:-webkit-transition "height 0.4s ease-in-out"

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -42,13 +42,13 @@
 
 (def FILE (r/atom nil))
 
-(def test-form [:myhidden-text {:type :hidden
-                                :default-value "whisper"}
-                :mydefault-text {:type :text
-                                 :label "default text"
-                                 :default-value "something good"
-                                 :disabled true
-                                 :style-classes "I-like-red"}
+(def test-form [;; :myhidden-text {:type :hidden
+                ;;                 :default-value "whisper"}
+                ;; :mydefault-text {:type :text
+                ;;                  :label "default text"
+                ;;                  :default-value "something good"
+                ;;                  :disabled true
+                ;;                  :style-classes "I-like-red"}
                 :mytext {:type :text
                          :label "My text"}
                 :mytextarea {:type :textarea
@@ -82,9 +82,9 @@
                 :myselect {:label "A select" :type :select :options [1 2 3]}
                 :myradio {:type :radio :options [1 2 {:value 3}]}
                 
-                :mytoggle {:type :togglebox
-                           :label "My togglebox"
-                           :content [:test {:type :text :label "My toggled "}]}
+                ;; :mytoggle {:type :togglebox
+                ;;            :label "My togglebox"
+                ;;            :content [:test {:type :text :label "My toggled "}]}
                 :mycheckbox {:type :checkbox :label "My checkbox" :default-value true}
                 :myfileupload {:type :file
                                :label "My file"

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -1,14 +1,15 @@
 (ns reformation.application
   "The application with which users fill out the form to make or edit an application"
-  (:require [reagent.core :as r]
-            [reagent.session :as session]
-            [reformation.shared-test :as shared]
-            [accountant.core]
-            [reformation.routes :as rt]
-            [reformation.core :as rfc]
+  (:require [accountant.core]
+            [cljs.pprint :as pprint]
             [re-frame.core :as reframe]
+            [reagent.core :as r]
+            [reagent.session :as session]
+            [reformation.core :as rfc]
             [reformation.reframe]
-            [cljs.pprint :as pprint]))
+            [reformation.routes :as rt]
+            [reformation.shared-test :as shared]
+            [taoensso.timbre :as log]))
 
 
 
@@ -82,10 +83,10 @@
                 :myselect {:label "A select" :type :select :options [1 2 3]}
                 :myradio {:type :radio :options [1 2 {:value 3}]}
                 
-                ;; :mytoggle {:type :togglebox
-                ;;            :label "My togglebox"
-                ;;            :content [:test {:type :text :label "My toggled "}]}
-                :mycheckbox {:type :checkbox :label "My checkbox" :default-value true}
+                :mytoggle {:type :togglebox
+                           :label "My togglebox"
+                           :content [:test {:type :text :label "My toggled "}]}
+                :mycheckbox {:type :checkbox :label "My checkbox"}
                 :myfileupload {:type :file
                                :label "My file"
                                :submit-text "Click or Drop a File Here"

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -43,13 +43,13 @@
 
 (def FILE (r/atom nil))
 
-(def test-form [;; :myhidden-text {:type :hidden
-                ;;                 :default-value "whisper"}
-                ;; :mydefault-text {:type :text
-                ;;                  :label "default text"
-                ;;                  :default-value "something good"
-                ;;                  :disabled true
-                ;;                  :style-classes "I-like-red"}
+(def test-form [:myhidden-text {:type :hidden
+                                :default-value "whisper"}
+                :mydefault-text {:type :text
+                                 :label "default text"
+                                 :default-value "something good"
+                                 :disabled true
+                                 :style-classes "I-like-red"}
                 :mytext {:type :text
                          :label "My text"}
                 :mytextarea {:type :textarea
@@ -86,7 +86,7 @@
                 :mytoggle {:type :togglebox
                            :label "My togglebox"
                            :content [:test {:type :text :label "My toggled "}]}
-                :mycheckbox {:type :checkbox :label "My checkbox"}
+                :mycheckbox {:type :checkbox :label "My checkbox" :default-value true}
                 :myfileupload {:type :file
                                :label "My file"
                                :submit-text "Click or Drop a File Here"

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -85,7 +85,7 @@
                 :mytoggle {:type :togglebox
                            :label "My togglebox"
                            :content [:test {:type :text :label "My toggled "}]}
-                :mycheckbox {:type :checkbox :label "My checkbox"}
+                :mycheckbox {:type :checkbox :label "My checkbox" :default-value true}
                 :myfileupload {:type :file
                                :label "My file"
                                :submit-text "Click or Drop a File Here"

--- a/test/cljs/reformation/reframe.cljs
+++ b/test/cljs/reformation/reframe.cljs
@@ -1,5 +1,6 @@
 (ns reformation.reframe
-  (:require [re-frame.core :as rfc]))
+  (:require [re-frame.core :as rfc]
+            [taoensso.timbre :as log]))
 
 (rfc/reg-event-db
  :update-form


### PR DESCRIPTION
The error was in the `init` function in `tinput` fn in `core.cljs`
It was previously `(and default-value (not (READ valpath)))` so that whenever checkbox value is false the condition is (not false) = true and updating the DB with default-value. 
Changed it to `(and default-value (nil? (READ valpath)))` so that it only updates to the default value when DB is nil (initialization).
![image](https://user-images.githubusercontent.com/47766633/113462622-fc4f2480-93de-11eb-9b0b-523334770f52.png)

Closes #26