### PR TITLE
Validation fix

### DIFF
--- a/README.org
+++ b/README.org
@@ -103,30 +103,30 @@ Toggleboxes are upgraded checkboxes.  They contain their own content, which is o
 
 *** universal keys
 **** =:type=
-indicates which element to create.  Can be any of: =:select=, =:radio=, =:multi-table=, =:textarea=, =:togglebox=, =:checkbox=, =:file=, =:hidden=
+Indicates which element to create.  Can be any of: =:select=, =:radio=, =:multi-table=, =:textarea=, =:togglebox=, =:checkbox=, =:file=, =:hidden=
 
 **** =:subtext=
 Explanatory or parenthetical text, appearing under =:label=.  Adjust style by adding rules to =p.help= 
 
 **** =:validation-function=
-should be a predicate function that takes a value and determines whether it is a valid input for that form element
+Should be a predicate function that takes a value and determines whether it is a valid input for that form element
 
 **** =:invalid-feedback=
 If the input doesn't satisfy the validation function, this string will appear explaining why
 
 **** =:required?=
-a boolean flag indicating whether the element is required for form submission.  Not applicable to  =togglebox or =multi-table=
+A boolean flag indicating whether the element is required for form submission.  Not applicable to  =togglebox or =multi-table=
 
 **** =:default-value= 
 If you wish to set a default value, put it here
      
 **** =:disabled=
-a binary flag for whether the element will be disabled
+A binary flag for whether the element will be disabled
 
 **** =:id= 
  the =id= of the resulting element
 **** =:style-classes=
-is set as =:class= of the resulting element
+Is set as =:class= of the resulting element
 
 
 ** Elements
@@ -192,7 +192,38 @@ An expandable table.  A common task for forms is a list of an indefinite number 
 ** TODO "required" on regular input
 ** TODO Format fn for date fields
 ** TODO Default values for select boxes
-** TODO Validation
+** Validation
+#+BEGIN_SRC clojure
+(rfc/check-form-validation)
+#+END_SRC
+A predicate function that will check the validity of every element in your form. Returns false if any do not pass the validation requirements.
+Currently supports the use of one form per page. 
+
+
+#+BEGIN_SRC clojure
+(ns example
+   (:require [reformation.core :as rfc]))
+
+(def f1 #(if (> (count %) 5)
+                 true
+                 nil))
+
+(def text-form [:example-element {:type :text
+                                  	:validation-function f1
+                                  	:invalid-feedback "Needs more than 5 characters..."
+                                  	:label "Enter more than 5 characters"	
+                                  	:id "example1"})
+
+(defn save-button
+  []
+	[:a.button {:id "submit"
+               :title "Submit form"
+               :on-click #(if (rfc/check-form-validation)
+                            (js/alert "Passed")
+                            (js/alert "Failed"))            
+               :href nil} "Submit"]])
+#+END_SRC
+
 ** Prerequisites
    :PROPERTIES:
    :CUSTOM_ID: prerequisites

--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
                    :plugins [[lein-codox "0.10.7"]
                              [com.jakemccrary/lein-test-refresh "0.14.0"]
                              [lein-doo "0.1.7"]
-                             [lein-figwheel "0.5.12"]
+                             [lein-figwheel "0.5.18"]
                              [org.clojure/clojurescript "1.10.439"]
                              [lein-cprop "1.0.1"]
                              [migratus-lein "0.4.3"]

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -4,7 +4,7 @@
             [reformation.shared :as shared]
             ;[reformation.validation :as vali]
             #?(:cljs [reagent.core :refer [atom]])
-            [clojure.string :as str]
+            [clojure.string :as string]
 
             ))
 (declare tinput render-application render-review)
@@ -35,13 +35,13 @@
    label-text])
 
 (defn select-box [m]
-  (let [{:keys [options id on-change required? style-classes]
+  (let [{:keys [options id on-change required style-classes]
          :or {id "generic-select"
               options ["No :options provided"]}} m]
     (into [:select.form-control {:class style-classes
                                  :id id
                                  :name id
-                                 :required required?
+                                 :required required
                                  :on-change on-change}]
           (for [{:keys [content value] :as o} options]
             (let [[c v] [(or content value o) (or value content o)]]
@@ -71,11 +71,11 @@
                [:label {:for idsym} disp]])))))
 
 
-(defn text-area
+(defn text-area 
   "Renders `:type :textarea` elements. In addition to the usual
   opts includes optional `:rows` for the html \"rows=\" attribute."
   [opt-map]
-  (let [{:keys [id input-value placeholder disabled label valpath changefn value char-count required class rows]
+  (let [{:keys [id input-value placeholder disabled label valpath changefn value char-count on-change required class rows]
          :or {rows 5}} opt-map
         {:keys [limit enforce?]} char-count
         
@@ -86,7 +86,7 @@
                                  :rows rows
                                  :default-value input-value
                                  :value value
-                                 :on-change changefn
+                                 :on-change on-change
                                  :required required
                                  :placeholder placeholder
                                  :disabled disabled}]]
@@ -117,7 +117,6 @@
                      (if (f v)
                        (.setCustomValidity dom-element "")
                        (.setCustomValidity dom-element error-message)))) {:validation-function? true})))
-
 
 (defn checkbox
   "Create a checkbox"
@@ -171,23 +170,42 @@
              :name id :id id
              :value value}]))
 
+(defn invalid-feedback-el [invalid-feedback]
+  [:div.invalid-feedback invalid-feedback])
+
+;id validation-function required? type default-value disabled subtext invalid-feedback char-count hidden style-classes contingent rows placeholder name-separator
+;;]
+;:or
+#_{name-separator "-"
+   id (string/join "-" (map name valpath))
+   type "text
+;"} ;} opt-map
+
+
 (defn tinput
   "Produce data-bound inputs for a given map, using `:READ` and `:UPDATE` for values and changes. `opt-map` specifies options including display variables."
   [{:keys [READ UPDATE] :as fn-map} valpath & [opt-map]]
-  (let [{:keys [id validation-function required? type default-value disabled subtext invalid-feedback char-count hidden style-classes contingent rows placeholder name-separator]
+  (let [{:keys [char-count contingent default-value disabled hidden id invalid-feedback required? style-classes subtext type validation-function rows placeholder name-separator]
          :or {name-separator "-"
-              id (str/join "-" (map name valpath))
+              id (string/join "-" (map name valpath))
               type "text"}} opt-map
         {:keys [limit enforce?]} char-count
         {:keys [field-key contingent-fn]} contingent
         _init (when (and default-value (not (READ valpath)))
                 (UPDATE valpath (constantly default-value)))
         input-value (or (READ valpath) default-value)
-        changefn1 (fn [e] (UPDATE valpath #(shared/get-value-from-change e)))
-        validation-function (when-let [vf validation-function]
-                              (to-validation vf invalid-feedback))
+        changefn1 (fn [e] (UPDATE valpath #(shared/get-value-from-change e))) ;if changes update val
+        call-validation-function (when-let [vf validation-function]
+                                   (to-validation vf invalid-feedback))
+        test-atom (atom nil)
+        pass (fn [e]
+               (if (to-validation-2 (shared/get-value-from-change e))
+                 true
+                 false))
         changefn (cond
-                   validation-function (fn [e] (doto e changefn1 validation-function))
+                   validation-function (fn [e] (doto e
+                                                 changefn1
+                                                 call-validation-function))
                    enforce? (fn [e]
                               (let [v (shared/get-value-from-change e)]
                                 (cond
@@ -195,7 +213,11 @@
                                   (< limit (count v)) #(UPDATE valpath (constantly (apply str (take limit v))))
                                   :default (changefn1 e))))
                    :default changefn1)
-        input-map (merge {:type type
+        opt-map (merge opt-map {:name id
+                                :on-change changefn
+                                :value input-value
+                                :required required?})
+        #_#_input-map (merge {:type type
                           :id id
                           :name id
                           :on-change changefn
@@ -210,27 +232,22 @@
                            {:required true})
                          (when rows
                            {:rows rows}))
-        invalid-feedback (when invalid-feedback
-                           [:div.invalid-feedback invalid-feedback])
+        
         input (case type
-                :radio [radio
-                        (merge (select-keys opt-map [:options :required?])
-
-                               {:on-change (fn [& args]
-                                             (apply changefn args))
-                                :id id})]
-
-                :select [select-box (merge (select-keys opt-map [:options :required?])
-                                           {:on-change changefn
-                                            :id id})]
+                :radio [radio opt-map]
+                :select [select-box opt-map]
                 :multi-table [multi-table fn-map opt-map]
-                :textarea [text-area (assoc input-map :changefn changefn)]
+                :textarea [text-area opt-map]
                 :togglebox [togglebox (merge (assoc fn-map :valpath valpath) opt-map)]
-                :checkbox [checkbox (assoc fn-map :valpath valpath) input-map]
+                :checkbox [checkbox (assoc fn-map :valpath valpath) opt-map]
                 :file [file-upload opt-map]
-                :hidden [hidden-input input-map]
+                :hidden [hidden-input opt-map]
                 ;; default
-                [:input.form-control input-map])]
+                [:input.form-control opt-map])]
+    
+    (println (str "\nFn-map:\n" fn-map))
+    (println (str "\nVal-path:\n" valpath))
+    (println (str "\nOpt-map:\n" opt-map))
     (case type
       :hidden input
       [:div.field
@@ -241,7 +258,11 @@
          [:p.help subtext])
        [:div.control      
         input
-        invalid-feedback]])))
+        (when invalid-feedback
+          [:div.invalid-feedback invalid-feedback])
+        (when (pass)
+          [:div.test
+           [:p (str "This works" pass)]])]])))
 
 (defn atom?
   "ducktype an atom as something dereferable"
@@ -250,7 +271,7 @@
        (catch #?(:clj Exception :cljs js/Error) _ false)))
 
 (defn render-application
-  "Render teh editable application.
+  "Render the editable application.
 
   `fm` is the schema of the application, a vector laying out the fields and their attributes.
   `fn-map` is either an Atom to hold the information a user inputs, or a map "

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -188,7 +188,7 @@
 (defn tinput
   "Produce data-bound inputs for a given map, using `:READ` and `:UPDATE` for values and changes. `opt-map` specifies options including display variables."
   [{:keys [READ UPDATE] :as fn-map} valpath & [opt-map]]
-  (let [{:keys [char-count contingent default-value disabled hidden id invalid-feedback required? style-classes subtext type validation-function rows placeholder name-separator]
+  (let [{:keys [char-count contingent default-value disabled hidden id invalid-feedback required style-classes subtext type validation-function rows placeholder name-separator]
          :or {name-separator "-"
               id (string/join "-" (map name valpath))
               type "text"}} opt-map
@@ -214,7 +214,7 @@
         opt-map (merge opt-map {:name id
                                 :on-change changefn
                                 :value input-value
-                                :required required?})
+                                :required required})
         input (case type
                 :radio [radio opt-map]
                 :select [select-box opt-map]

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -120,10 +120,12 @@
                        (do
                          (.setCustomValidity dom-element "")
                          (.reportValidity dom-element)
+                         (-> dom-element .-classList (.remove "invalid"))
                          )
                        (do
                          (.setCustomValidity dom-element error-message)
                          (.reportValidity dom-element)
+                         (-> dom-element .-classList (.add "invalid"))
                          )))) {:validation-function? true})))
 
 (defn checkbox

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -1,13 +1,16 @@
 (ns reformation.core
   (:require [reformation.multitable :refer [multi-table] :as mt]
             [reformation.fileupload :refer [file-upload]]
+            [reformation.validateform :refer [validate-form]]
             [reformation.shared :as shared]
             ;[reformation.validation :as vali]
             #?(:cljs [reagent.core :refer [atom]])
-            [clojure.string :as string]
+            [clojure.string :as string]))
 
-            ))
 (declare tinput render-application render-review)
+
+(defn check-form-validation []
+  (validate-form))
 
 
 (defn map-structure

--- a/src/reformation/core.cljc
+++ b/src/reformation/core.cljc
@@ -115,7 +115,6 @@
   [f & [error-message]]
   (if (validation-function? f) f 
       (with-meta (fn [click]
-                   (println "Got here")
                    (let [v (.. click -target -value)
                          dom-element (.. click -target)
                          error-message (or error-message "Invalid input")]
@@ -186,15 +185,6 @@
 (defn invalid-feedback-el [invalid-feedback]
   [:div.invalid-feedback invalid-feedback])
 
-;id validation-function required? type default-value disabled subtext invalid-feedback char-count hidden style-classes contingent rows placeholder name-separator
-;;]
-;:or
-#_{name-separator "-"
-   id (string/join "-" (map name valpath))
-   type "text
-;"} ;} opt-map
-
-
 (defn tinput
   "Produce data-bound inputs for a given map, using `:READ` and `:UPDATE` for values and changes. `opt-map` specifies options including display variables."
   [{:keys [READ UPDATE] :as fn-map} valpath & [opt-map]]
@@ -204,7 +194,7 @@
               type "text"}} opt-map
         {:keys [limit enforce?]} char-count
         {:keys [field-key contingent-fn]} contingent
-        _init (when (and default-value (not (READ valpath)))
+        _init (when (and default-value (nil? (READ valpath)))
                 (UPDATE valpath (constantly default-value)))
         input-value (or (READ valpath) default-value)
         changefn1 (fn [e] (UPDATE valpath #(shared/get-value-from-change e))) ;if changes update val
@@ -225,22 +215,6 @@
                                 :on-change changefn
                                 :value input-value
                                 :required required?})
-        #_#_input-map (merge {:type type
-                          :id id
-                          :name id
-                          :on-change changefn
-                          :default-value default-value
-                          :placholder placeholder
-                          :value input-value}
-                         (when style-classes
-                           {:class style-classes})
-                         (when disabled
-                           {:disabled disabled})
-                         (when required?
-                           {:required true})
-                         (when rows
-                           {:rows rows}))
-        
         input (case type
                 :radio [radio opt-map]
                 :select [select-box opt-map]
@@ -252,10 +226,6 @@
                 :hidden [hidden-input opt-map]
                 ;; default
                 [:input.form-control opt-map])]
-    
-    (println (str "\nFn-map:\n" fn-map))
-    (println (str "\nVal-path:\n" valpath))
-    (println (str "\nOpt-map:\n" opt-map))
     (case type
       :hidden input
       [:div.field

--- a/src/reformation/validateform.clj
+++ b/src/reformation/validateform.clj
@@ -1,0 +1,6 @@
+(ns reformation.validateform)
+
+(defn validate-form
+  "Unspecified for clj"
+  [&_]
+  (println "This did not work"))

--- a/src/reformation/validateform.cljs
+++ b/src/reformation/validateform.cljs
@@ -3,8 +3,6 @@
 (defn validate-form []
   (let [form (.getElementById js/document "needs-validation")]
     (if (.checkValidity form)
-      (js/alert "YES")
-      (js/alert "NO")
-                                        ;true
-                                        ;false
+      true
+      false
       )))

--- a/src/reformation/validateform.cljs
+++ b/src/reformation/validateform.cljs
@@ -1,0 +1,10 @@
+(ns reformation.validateform)
+
+(defn validate-form []
+  (let [form (.getElementById js/document "needs-validation")]
+    (if (.checkValidity form)
+      (js/alert "YES")
+      (js/alert "NO")
+                                        ;true
+                                        ;false
+      )))

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -14,20 +14,38 @@
 
 ;render-application returns a VECTOR with tinput at the front
 
-(def f #(if (> (count %) 5)
+(def f1 #(if (> (count %) 5)
                  true
                  nil))
-(f "12345")
+(f1 "12345")
+(def f2 #(if (= "@" %)
+           true
+           nil))
 
 (def example-atom (atom nil))
 
-
+(defn built-in-email-constraint
+  []
+  [:div
+   [:input {:type "text"
+           :value ""
+           :on-change #()}]
+   ])
 
 (def easy-form [:example-element {:type :text
-                                  :validation-function f
+                                  :validation-function f1
                                   :invalid-feedback "Needs more than 5 characters..."
-                                  :label "Enter some text here"
-                                  :id "example1"}])
+                                  :label "Enter more than 5 characters"
+                                  :id "example1"}
+                :example_element2 {:type :text
+                                   :validation-function f2
+                                   :invalid-feedback "Just type @..."
+                                   :label "Enter the @ symbol"
+                                   :id "example2"}
+                #_#_:example_email {:type :email
+                                :label "Enter email"
+                                :is "email"}
+                ])
 (def id "example1")
 
 #_(defn check-valid-fn
@@ -47,15 +65,16 @@
    [rfc/render-application easy-form example-atom]
    #_(rfc/render-application easy-form example-atom)])
 
-;;(. (. js/document getElementById "example1") -value) 
+;;(. (. js/document getElementById "example1") -value)
+(comment (def form-dom-id "example1"))
 
 (defn validate-and-submit "Validate the form and submit"
   [form-dom-id]
-  (let [form (.getElementById js/document "example1")
-        update-id (session/get :application)
+  (let [form (.getElementById js/document form-dom-id)
+        ;update-id (session/get :application)
         ]
-    (-> form .-classList (.add "was-validated"))
-    #_(if (.checkValidity form)
+    (-> form .-classList (.add "invalid"))
+    (if (.checkValidity form)
       (js/alert "Passes validation")
       (js/alert "Didn't Pass Validation"))))
 
@@ -146,7 +165,14 @@
                                :allowed-extensions-f #{"txt"}
                                :style-classes {:drag-over "dragover"
                                                :inactive "undragged"
-                                               :have-file "have-file"}}])
+                                               :have-file "have-file"}}
+                [:a.button {:id "Save"
+                            :alt "Save"
+                            :type :submit
+                            :title "Save"
+                            ;;:on-click validate-and-submit
+                            :href nil}
+                 "Save"]])
 
 (def data-sources {:atom my-atom
                    :map {:READ
@@ -166,8 +192,10 @@
   [:div {:style {:margin-top "10px"}}
    [:a.button {:id "Save"
                :alt "Save"
-               :title "Save"
-               :on-click validate-and-submit
+               :type :submit
+               :title "Submit form"
+               :form "needs-validation"
+               :on-click #(validate-and-submit "needs-validation")
                :href nil}
     "Save"]])
 
@@ -179,6 +207,7 @@
             (rfc/render-application easy-form (data-sources @chosen-datasource))
             ;(rfc/render-application test-form  (data-sources @chosen-datasource))
             )]]))
+
 
 (defn datasource-panel []
   [:div [:span {:on-click (fn [e]

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -17,20 +17,11 @@
 (def f1 #(if (> (count %) 5)
                  true
                  nil))
-(f1 "12345")
 (def f2 #(if (= "@" %)
            true
            nil))
 
 (def example-atom (atom nil))
-
-(defn built-in-email-constraint
-  []
-  [:div
-   [:input {:type "text"
-           :value ""
-           :on-change #()}]
-   ])
 
 (def easy-form [:example-element {:type :text
                                   :validation-function f1
@@ -41,71 +32,9 @@
                                    :validation-function f2
                                    :invalid-feedback "Just type @..."
                                    :label "Enter the @ symbol"
-                                   :id "example2"}
-                #_#_:example_email {:type :email
-                                :label "Enter email"
-                                :is "email"}
-                ])
-(def id "example1")
+                                   :id "example2"}])
 
-#_(defn check-valid-fn
-  [id]
-  (.reportValidity
-    (.getElementById js/document id)))
-
-#_(defn add-red-outline-fn
-  [id]
-  (. (.getElementById js/document id) setAttribute "style" "border: 2px solid #FF0000"))
-
-;(check-valid-fn "example1")
-;(add-red-outline-fn "example1")
-
-(defn form-component []
-  [:div
-   [rfc/render-application easy-form example-atom]
-   #_(rfc/render-application easy-form example-atom)])
-
-;;(. (. js/document getElementById "example1") -value)
-(comment (def form-dom-id "example1"))
-
-(defn validate-and-submit "Validate the form and submit"
-  [form-dom-id]
-  (let [form (.getElementById js/document form-dom-id)
-        ;update-id (session/get :application)
-        ]
-    (-> form .-classList (.add "invalid"))
-    (if (.checkValidity form)
-      (js/alert "Passes validation")
-      (js/alert "Didn't Pass Validation"))))
-
-
-
-(defn validation-function?
-  [f]
-  (:validation-function? (meta f)))
-
-(defn to-validation 
-  "Given a predicate, wrap it properly to be a validation function for tinput.
-
-  Validation function runs on the input at every change, altering the validity of the element as prescribed. It waits for .checkValidity on the input to explain the error"
-  [f & [error-message]]
-  (if (validation-function? f) f 
-      (with-meta (fn [click]
-                   (let [v (. (. js/document getElementById "example1") -value) 
-                         dom-element (. js/document getElementById "example1")
-                         ;v (.. click -target -value)
-                         ;dom-element (.. click -target)
-                         error-message (or error-message "Invalid input")]
-                     (if (f v)
-                       (.setCustomValidity dom-element "")
-                       (.setCustomValidity dom-element error-message)))) {:validation-function? true}
-        )
-     ) (println (str "VALIDATION FN:\n" (:validation-function (meta f)))))
-
-
-
-(def my-atom (r/atom nil;{:mything "hello"}
-              ))
+(def my-atom (r/atom nil))
 
 (def FILE (r/atom nil))
 
@@ -195,8 +124,11 @@
                :type :submit
                :title "Submit form"
                :form "needs-validation"
-               :on-click #(rfc/check-form-validation)
-                                        ;#(validate-and-submit "needs-validation")
+               :on-click #(if (rfc/check-form-validation)
+                            ;(js/alert "We did it")
+                            (reframe/dispatch [:reset])
+                            (js/alert "Please fill out all fields properly."))
+                                        
                :href nil}
     "Save"]])
 

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -195,7 +195,8 @@
                :type :submit
                :title "Submit form"
                :form "needs-validation"
-               :on-click #(validate-and-submit "needs-validation")
+               :on-click #(rfc/check-form-validation)
+                                        ;#(validate-and-submit "needs-validation")
                :href nil}
     "Save"]])
 

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -2,43 +2,67 @@
   "The application with which users fill out the form to make or edit an application"
   (:require [reagent.core :as r]
             [reagent.session :as session]
-            [reformation.shared-test :as shared]
+            ;[reformation.shared-test :as shared]
             [accountant.core]
-            [reformation.routes :as rt]
+            ;[reformation.routes :as rt]
             [reformation.core :as rfc]
             [re-frame.core :as reframe]
-            [reformation.reframe]
+            ;[reformation.reframe]
             [cljs.pprint :as pprint]))
 
 
 
 ;render-application returns a VECTOR with tinput at the front
 
-
+(def simplefn #(if (> (count %) 5)
+                 true
+                 nil))
 
 (def example-atom (atom nil))
-(def easy-form [:example-element {:type :text
-                                   :label "Enter some text here"}
-		:example-element2 {:type :checkbox
- 		                   :label "Is it true?"}])
 
+
+
+(def easy-form [:example-element {:type :text
+                                  :validation-function? simplefn
+                                  :invalid-feedback "Incorrect Input..."
+                                  :label "Enter some text here"
+                                  :id "example1"}
+                ])
+(def id "example1")
+
+(defn check-valid-fn
+  [id]
+  (.reportValidity
+    (.getElementById js/document id)))
+
+(defn add-red-outline-fn
+  [id]
+  (. (.getElementById js/document id) setAttribute "style" "border: 2px solid #FF0000"))
+
+;(check-valid-fn "example1")
+;(add-red-outline-fn "example1")
 
 (defn form-component []
   [:div
    [rfc/render-application easy-form example-atom]
    #_(rfc/render-application easy-form example-atom)])
 
-
+;;(. (. js/document getElementById "example1") -value) 
 
 (defn validate-and-submit "Validate the form and submit"
   [form-dom-id]
-  (let [form (.getElementById js/document form-dom-id)
-        update-id (session/get :application)]
-    (-> form .-classList (.add "was-validated"))
+  (let [form (.getElementById js/document "example1")
+        ;update-id (session/get :application)
+        ]
+    ;(-> form .-classList (.add "was-validated"))
     (if (.checkValidity form)
-      (js/alert "You have errors in your form. Please correct them before submitting."))))
+      (js/alert "Passes validation")
+      (js/alert "Didn't Pass Validation"))))
 
-(def my-atom (r/atom {:mything "hello"}))
+
+
+(def my-atom (r/atom nil;{:mything "hello"}
+              ))
 
 (def FILE (r/atom nil))
 
@@ -111,12 +135,24 @@
 
 (def chosen-datasource (r/atom :atom))
 
+(defn save-button
+  []
+  [:div {:style {:margin-top "10px"}}
+   [:a.button {:id "Save"
+               :alt "Save"
+               :title "Save"
+               :on-click validate-and-submit
+               :href nil}
+    "Save"]])
+
 (defn generate-form []
   (let [form-id "needs-validation"]
     [:div.submission-form 
      [:form.form-control {:id form-id}
       (into [:div.form-contents]
-            (rfc/render-application test-form  (data-sources @chosen-datasource)))]]))
+            (rfc/render-application easy-form (data-sources @chosen-datasource))
+            ;(rfc/render-application test-form  (data-sources @chosen-datasource))
+            )]]))
 
 (defn datasource-panel []
   [:div [:span {:on-click (fn [e]
@@ -136,4 +172,5 @@
    [datasource-panel]
    [data-panel]
    #_[form-component]
+   [save-button]
    ])

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -24,18 +24,18 @@
 
 
 (def easy-form [:example-element {:type :text
-                                  :validation-function? f
-                                  :invalid-feedback "Incorrect Input..."
+                                  :validation-function f
+                                  :invalid-feedback "Needs more than 5 characters..."
                                   :label "Enter some text here"
                                   :id "example1"}])
 (def id "example1")
 
-(defn check-valid-fn
+#_(defn check-valid-fn
   [id]
   (.reportValidity
     (.getElementById js/document id)))
 
-(defn add-red-outline-fn
+#_(defn add-red-outline-fn
   [id]
   (. (.getElementById js/document id) setAttribute "style" "border: 2px solid #FF0000"))
 
@@ -52,10 +52,10 @@
 (defn validate-and-submit "Validate the form and submit"
   [form-dom-id]
   (let [form (.getElementById js/document "example1")
-        ;update-id (session/get :application)
+        update-id (session/get :application)
         ]
-    ;(-> form .-classList (.add "was-validated"))
-    (if (.checkValidity form)
+    (-> form .-classList (.add "was-validated"))
+    #_(if (.checkValidity form)
       (js/alert "Passes validation")
       (js/alert "Didn't Pass Validation"))))
 

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -23,15 +23,17 @@
 
 (def example-atom (atom nil))
 
-(def easy-form [:example-element {:type :text
+(def text-form [:example-element {:type :text
                                   :validation-function f1
                                   :invalid-feedback "Needs more than 5 characters..."
                                   :label "Enter more than 5 characters"
+                                  :required true 
                                   :id "example1"}
                 :example_element2 {:type :text
                                    :validation-function f2
                                    :invalid-feedback "Just type @..."
                                    :label "Enter the @ symbol"
+                                   :required true
                                    :id "example2"}])
 
 (def my-atom (r/atom nil))
@@ -125,8 +127,9 @@
                :title "Submit form"
                :form "needs-validation"
                :on-click #(if (rfc/check-form-validation)
-                            ;(js/alert "We did it")
-                            (reframe/dispatch [:reset])
+                            (do
+                              (js/alert "Passed Validation")
+                              (reset! my-atom nil))
                             (js/alert "Please fill out all fields properly."))
                                         
                :href nil}
@@ -137,7 +140,7 @@
     [:div.submission-form 
      [:form.form-control {:id form-id}
       (into [:div.form-contents]
-            (rfc/render-application easy-form (data-sources @chosen-datasource))
+            (rfc/render-application text-form (data-sources @chosen-datasource))
             ;(rfc/render-application test-form  (data-sources @chosen-datasource))
             )]]))
 

--- a/test/cljs/reformation/application.cljs
+++ b/test/cljs/reformation/application.cljs
@@ -120,20 +120,13 @@
 
 (defn save-button
   []
-  [:div {:style {:margin-top "10px"}}
-   [:a.button {:id "Save"
-               :alt "Save"
-               :type :submit
-               :title "Submit form"
-               :form "needs-validation"
-               :on-click #(if (rfc/check-form-validation)
-                            (do
-                              (js/alert "Passed Validation")
-                              (reset! my-atom nil))
-                            (js/alert "Please fill out all fields properly."))
-                                        
-               :href nil}
-    "Save"]])
+  [:a.button {:id "Save"
+              :title "Submit form"
+              :on-click #(if (rfc/check-form-validation)
+                           (js/alert "Passed")
+                           (js/alert "Failed"))
+              :href nil} "Save"])
+
 
 (defn generate-form []
   (let [form-id "needs-validation"]

--- a/test/cljs/reformation/reframe.cljs
+++ b/test/cljs/reformation/reframe.cljs
@@ -12,3 +12,8 @@
  (fn [db [_ kv]]
    (let [path (into [:form] kv)]
      (get-in db path))))
+
+(rfc/reg-event-db
+ :reset
+ (fn reset [db [_]]
+   (assoc-in db [:form] nil)))

--- a/test/resources/public/css/style.css
+++ b/test/resources/public/css/style.css
@@ -225,13 +225,13 @@ div.submission-form form div.upload .error {
   color: #dc3545;
 }
 
+.invalid {
+  border-color: #dc3545;
+}
+
 div.submission-form form .invalid-feedback {
   display: none;
   color: #dc3545;
-}
-
-.invalid {
-  border-color: #FF3232;
 }
 
 .was-validated .form-control:invalid ~ .invalid-feedback {

--- a/test/resources/public/css/style.css
+++ b/test/resources/public/css/style.css
@@ -219,6 +219,12 @@ div.submission-form form div.upload.dragover {
   border-width: 10px;
 }
 
+.invalid {
+  border-color: #dc3545;
+  border-radius: 5px;
+  border-width: 2px;
+}
+
 div.submission-form form div.upload .error {
   display: block;
   bottom: -20px;
@@ -233,6 +239,8 @@ div.submission-form form .invalid-feedback {
 .was-validated .form-control:invalid ~ .invalid-feedback {
   display: block;
 }
+
+
 
 .review-page review-application {
   background-color: #fff;

--- a/test/resources/public/css/style.css
+++ b/test/resources/public/css/style.css
@@ -219,16 +219,15 @@ div.submission-form form div.upload.dragover {
   border-width: 10px;
 }
 
-.invalid {
-  border-color: #dc3545;
-  border-radius: 5px;
-  border-width: 2px;
-}
-
 div.submission-form form div.upload .error {
   display: block;
   bottom: -20px;
   color: #dc3545;
+}
+
+.invalid {
+  border-color: #dc3545;
+  
 }
 
 div.submission-form form .invalid-feedback {
@@ -239,8 +238,6 @@ div.submission-form form .invalid-feedback {
 .was-validated .form-control:invalid ~ .invalid-feedback {
   display: block;
 }
-
-
 
 .review-page review-application {
   background-color: #fff;

--- a/test/resources/public/css/style.css
+++ b/test/resources/public/css/style.css
@@ -225,14 +225,13 @@ div.submission-form form div.upload .error {
   color: #dc3545;
 }
 
-.invalid {
-  border-color: #dc3545;
-  
-}
-
 div.submission-form form .invalid-feedback {
   display: none;
   color: #dc3545;
+}
+
+.invalid {
+  border-color: #FF3232;
 }
 
 .was-validated .form-control:invalid ~ .invalid-feedback {


### PR DESCRIPTION
Fixes validation for text fields and can set custom validation message. 
Fields should be highlighted red when not passing custom validation. 
:required attribute works. 
Added a new predicate function _rfc/check-form-validation_ to check the validity of the form before submission. 


